### PR TITLE
Corrected Dockerfile link

### DIFF
--- a/ml/notebook_examples/hosted_kfp/event_triggered_kfp_pipeline_bw.ipynb
+++ b/ml/notebook_examples/hosted_kfp/event_triggered_kfp_pipeline_bw.ipynb
@@ -343,7 +343,7 @@
     "\n",
     "We'll define both TFDV pipeline *components* as ['lightweight' Python-function-based components](https://www.kubeflow.org/docs/pipelines/sdk/python-function-components/). For each component, we define a function, then call `kfp.components.func_to_container_op()` on that function to build a reusable component in `.yaml` format. \n",
     "\n",
-    "For these components, we need to specify a base container image that will run the function.  We'll use one that has the TFDV libraries installed (its Dockerfile is [here](https://github.com/amygdala/code-snippets/blob/keras_tuner3/ml/kubeflow-pipelines/keras_tuner/components/tfdv/Dockerfile))."
+    "For these components, we need to specify a base container image that will run the function.  We'll use one that has the TFDV libraries installed (its Dockerfile is [here](https://github.com/amygdala/code-snippets/blob/master/ml/kubeflow-pipelines/keras_tuner/components/tfdv/Dockerfile))."
    ]
   },
   {


### PR DESCRIPTION
The dockerfile link in the notebook (event_triggered_kfp_pipeline_bw.ipynb) is broken, replaced it with the correct link.